### PR TITLE
fix: Calculate correct Avg and StdDev

### DIFF
--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -72,7 +72,7 @@
         &nbsp;
       </div>
 
-      <div ng-show="showAverage" class="voting-average">Average: <b>{{votingAverage}} (SD = {{votingStandardDeviation}})</b></div>
+      <div ng-show="showAverage" class="voting-average">Average: <b>{{votingAverage}} (StdDev = {{votingStandardDeviation}})</b></div>
     </div>
 
     <div ng-switch on="showAdmin" >


### PR DESCRIPTION
When non-numeric votes are present average and standard deviation was calculated incorrectly - basically displayed as `null`. This fix converts 1/2  and playing cards votes to numbers and reject other non-numeric votes. Don't show average when there is no data (e.g T-Shirt card deck).